### PR TITLE
Support round-trips through serialisation

### DIFF
--- a/src/edjCase.SendGrid.WebHooks/WebHookConverters.cs
+++ b/src/edjCase.SendGrid.WebHooks/WebHookConverters.cs
@@ -20,6 +20,8 @@ namespace edjCase.SendGrid.WebHooks
 			double? unixTimestamp;
 			switch (reader.Value)
 			{
+				case DateTime dateTimeValue:
+					return dateTimeValue;
 				case long longValue:
 					unixTimestamp = longValue;
 					break;
@@ -94,6 +96,11 @@ namespace edjCase.SendGrid.WebHooks
 
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
 		{
+			if (existingValue is EventType)
+			{
+				return existingValue;
+			}
+			
 			string eventType = (string)reader.Value;
 			switch (eventType)
 			{
@@ -139,6 +146,11 @@ namespace edjCase.SendGrid.WebHooks
 
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
 		{
+			if (existingValue is WebHookEvent)
+			{
+				return existingValue;
+			}
+			
 			JObject jObject = JObject.Load(reader);
 			string eventType = jObject["event"].Value<string>();
 			WebHookEvent webHookEvent;


### PR DESCRIPTION
If a `WebHookEvent` instance is serialised, for example as an argument to a Hangfire background job, the converters cannot handle the already-converted .NET objects.

This change short-circuits out of the converter if the type already matches its target type.